### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description of the change
+
+> Description here
+
+## Type of change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Related issues
+
+> Fix [#1]() 
+
+## Checklists
+
+### Development
+
+- [ ] Lint rules pass locally
+- [ ] The code changed/added as part of this pull request has been covered with tests
+- [ ] All tests related to the changed code pass in development
+
+### Code review 
+
+- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
+- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
+- [ ] Changes have been reviewed by at least one other engineer
+- [ ] Issue from task tracker has a link to this pull request 


### PR DESCRIPTION
A PR template is required to pass compliance.

Using generic PR template from https://github.com/VantaInc/sdlc-templates/blob/master/.github/pull_request_template.md

Feel free to change as needed.