### PR TITLE
Update exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## 2.3.x Releases
+
+- `2.3.x` Releases - [2.3.4](#234)
+
+---
+
+### 2.3.4
+
+#### Added
+
+- Export `EventPayload` type.
+- Export `PinwheelError` type.
+- Export `PinwheelErrorType` type.
+- Export `EmptyPayloadObject` type as `Record<string, never>`.
+
+##### Updated
+
+- `EventPayload` is no longer a union containing `{}`. It now contains `Record<string, never>` instead due to [this behavior](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-all-types-assignable-to-empty-interfaces).
+- Mark exported `Error` type as **@deprecated** because it collides with the built-in javascript `Error` object. Replaced with `PinwheelError`.
+- Mark exported `ErrorType` type as **@deprecated** because the new naming convention is prefixing with "`PinwheelError`". Replaced with `PinwheelErrorType`.
+- Update `onExit` type to be `(error: PinwheelError | Record<string, never>)` to be accurate with current functionality.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "PinwheelRNExample",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,10 @@ export type LinkResult = {
   };
 };
 
+/**
+ * @deprecated This type will be removed in version 2.4. Use the renamed type`PinwheelErrorType`
+ * instead.
+ */
 export type ErrorType =
   | 'clientError'
   | 'systemError'
@@ -39,12 +43,14 @@ export type ErrorType =
   | 'invalidUserInput'
   | 'invalidLinkToken';
 
+export type PinwheelErrorType = ErrorType
+
 /**
  * @deprecated The type should not be used as it clashes with the native JS `Error` object.
  * You should use `PinwheelError` instead. `Error` will be removed in version 2.4
  */
 export type Error = {
-  type: ErrorType;
+  type: PinwheelErrorType;
   code: string;
   message: string;
   pendingRetry: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ export type LinkResult = {
 };
 
 /**
- * @deprecated This type will be removed in version 2.4. Use the renamed type`PinwheelErrorType`
+ * @deprecated This type will be removed in version 2.4. Use the renamed type `PinwheelErrorType`
  * instead.
  */
 export type ErrorType =
@@ -59,7 +59,7 @@ export type Error = {
 // Export `Error` as `PinwheelError` to avoid native `Error` namespace clash
 export type PinwheelError = Error
 
-export type EmptyPayloadObject = {}
+export type EmptyPayloadObject = Record<string, never>
 
 export type EventPayload =
   | { selectedEmployerId: string; selectedEmployerName: string }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,10 @@ export type ErrorType =
   | 'invalidUserInput'
   | 'invalidLinkToken';
 
+/**
+ * @deprecated The type should not be used as it clashes with the native JS `Error` object.
+ * You should use `PinwheelError` instead. `Error` will be removed in version 2.4
+ */
 export type Error = {
   type: ErrorType;
   code: string;
@@ -46,14 +50,19 @@ export type Error = {
   pendingRetry: boolean;
 };
 
-type EventPayload =
+// Export `Error` as `PinwheelError` to avoid native `Error` namespace clash
+export type PinwheelError = Error
+
+export type EmptyPayloadObject = {}
+
+export type EventPayload =
   | { selectedEmployerId: string; selectedEmployerName: string }
   | { selectedPlatformId: string; selectedPlatformName: string }
   | { value: number; unit: '%' | '$' }
   | LinkResult
   | { accountId: string; platformId: string }
-  | Error
-  | {}
+  | PinwheelError
+  | EmptyPayloadObject
   | undefined
 
 type PinwheelProps = {
@@ -61,8 +70,8 @@ type PinwheelProps = {
   onLogin?: (result: { accountId: string; platformId: string }) => void;
   onLoginAttempt?: (result: { platformId: string }) => void;
   onSuccess?: (result: LinkResult) => void;
-  onError?: (error: Error) => void;
-  onExit?: (error?: Error) => void;
+  onError?: (error: PinwheelError) => void;
+  onExit?: (error: PinwheelError | EmptyPayloadObject) => void;
   onEvent?: (eventName: string, payload: EventPayload) => void;
 }
 
@@ -85,7 +94,7 @@ export default ({linkToken, onLogin, onLoginAttempt, onSuccess, onError, onExit,
     try {
       eventData = JSON.parse(event.nativeEvent.data);
     } catch(_error) {
-      let error: Error = (_error as Error);
+      let error: PinwheelError = (_error as PinwheelError);
       console.error(error);
       onExit && onExit(error);
       onError && onError(error);


### PR DESCRIPTION
## Description of the change

- Export EventPayload
- EventPayload is a union that contains the type `{}`, which was probably unintended, since anything is assignable to type `{}` ([FAQ · microsoft/TypeScript Wiki](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-all-types-assignable-to-empty-interfaces)). We should use `Record<string, never>` to signify an empty object
- Export a type named `PinwheelError` instead of `Error` because it collides with the built-in javascript `Error` object
- Update `onExit` type to be `(error: PinwheelError | Record<string, never>)` to be accurate with current functionality

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [PP-6201](https://pinwheel.atlassian.net/browse/PP-6201) 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
