### PR TITLE
Handle window insets in edge-to-edge mode on Android, bump to V3.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
   google()
 }
 
-def PW_ANDROID_SDK_VERSION = '3.1.1'
+def PW_ANDROID_SDK_VERSION = '3.1.2'
 
 dependencies {
     def pwVersion = rootProject.hasProperty('pwVersion') ? rootProject.pwVersion : PW_ANDROID_SDK_VERSION

--- a/android/src/main/java/com/rtnpinwheel/Pinwheel.kt
+++ b/android/src/main/java/com/rtnpinwheel/Pinwheel.kt
@@ -20,6 +20,7 @@ class Pinwheel : FrameLayout {
   private var token: String? = null
   private var pinwheelFragment: PinwheelFragment? = null
   private var pinwheelEventListener: PinwheelEventListener? = null
+  private var handleInsets: Boolean = true
 
   constructor(context: Context) : super(context) {
     init()
@@ -46,6 +47,10 @@ class Pinwheel : FrameLayout {
     this.token = token
   }
 
+  fun setHandleInsets(handleInsets: Boolean) {
+    this.handleInsets = handleInsets
+  }
+
   fun getReactNativeVersion(): String {
     val version = ReactNativeVersion.VERSION
     return "${version["major"]}.${version["minor"]}.${version["patch"]}"
@@ -54,7 +59,7 @@ class Pinwheel : FrameLayout {
   private fun createFragment() {
     Handler(Looper.getMainLooper()).post {
       this.token?.let {
-        val pinwheelFragment = PinwheelFragment.newInstance(it, "react native", "3.2.0", getReactNativeVersion())
+        val pinwheelFragment = PinwheelFragment.newInstance(it, "react native", "3.2.1", getReactNativeVersion(), this.handleInsets)
         pinwheelEventListener?.let { listener ->
           pinwheelFragment.pinwheelEventListener = listener
         }

--- a/android/src/main/java/com/rtnpinwheel/PinwheelManager.kt
+++ b/android/src/main/java/com/rtnpinwheel/PinwheelManager.kt
@@ -12,7 +12,7 @@ import com.facebook.react.viewmanagers.RTNPinwheelManagerInterface
 import com.facebook.react.viewmanagers.RTNPinwheelManagerDelegate
 
 @ReactModule(name = PinwheelManager.NAME)
-class PinwheelManager(private val reactContext: ReactApplicationContext) : 
+class PinwheelManager(private val reactContext: ReactApplicationContext) :
     SimpleViewManager<Pinwheel>(),
     RTNPinwheelManagerInterface<Pinwheel> {
 
@@ -29,13 +29,18 @@ class PinwheelManager(private val reactContext: ReactApplicationContext) :
         (reactContext.getNativeModule(PinwheelEventsModule::class.java) as? PinwheelEventsModule)?.let { module ->
             view.setPinwheelEventListener(module)
         }
-        
+
         return view
     }
 
     @ReactProp(name = "token")
     override fun setToken(view: Pinwheel, token: String?) {
         view.setToken(token)
+    }
+
+    @ReactProp(name = "handleInsets")
+    override fun setHandleInsets(view: Pinwheel, handleInsets: Boolean) {
+        view.setHandleInsets(handleInsets)
     }
 
     @ReactPropGroup(names = ["width", "height"], customType = "Style")

--- a/ios/RTNPinwheelView.mm
+++ b/ios/RTNPinwheelView.mm
@@ -38,7 +38,7 @@ using namespace facebook::react;
 
 - (void)initPinwheelWrapperVC {
     if (self.token != nil && self.pinwheelWrapperVC == nil) {
-        self.pinwheelWrapperVC = [[PinwheelVCWrapper alloc] initWithToken:self.token delegate:self sdk:@"react native" version: @"3.2.0"];
+        self.pinwheelWrapperVC = [[PinwheelVCWrapper alloc] initWithToken:self.token delegate:self sdk:@"react native" version: @"3.2.1"];
         [self addSubview:self.pinwheelWrapperVC.view];
     }
 }
@@ -102,7 +102,7 @@ Class<RCTComponentViewProtocol> RTNPinwheelCls(void)
   return RTNPinwheelView.class;
 }
 
-#else 
+#else
 
 #import "RTNPinwheelView.h"
 #import "RTNPinwheelEvents.h"
@@ -125,7 +125,7 @@ Class<RCTComponentViewProtocol> RTNPinwheelCls(void)
 
 - (void)initPinwheelWrapperVC {
     if (self.token != nil && self.pinwheelWrapperVC == nil) {
-        self.pinwheelWrapperVC = [[PinwheelVCWrapper alloc] initWithToken:self.token delegate:self sdk:@"react native" version: @"3.2.0"];
+        self.pinwheelWrapperVC = [[PinwheelVCWrapper alloc] initWithToken:self.token delegate:self sdk:@"react native" version: @"3.2.1"];
         [self addSubview:self.pinwheelWrapperVC.view];
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-native-pinwheel",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-native-pinwheel",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react-native": "^0.72.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-native-pinwheel",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/src/Pinwheel.d.ts
+++ b/src/Pinwheel.d.ts
@@ -1,4 +1,6 @@
 import React from 'react';
 import { LinkOptions } from './client-events/client';
-declare const Pinwheel: ({ linkToken, onLogin, onLoginAttempt, onSuccess, onError, onExit, onEvent, }: LinkOptions) => React.JSX.Element;
+declare const Pinwheel: ({ linkToken, onLogin, onLoginAttempt, onSuccess, onError, onExit, onEvent, handleInsets, }: LinkOptions & {
+    handleInsets?: boolean;
+}) => React.JSX.Element;
 export default Pinwheel;

--- a/src/Pinwheel.tsx
+++ b/src/Pinwheel.tsx
@@ -17,7 +17,10 @@ const Pinwheel = ({
   onError,
   onExit,
   onEvent,
-}: LinkOptions) => {
+  handleInsets,
+}: LinkOptions & {
+  handleInsets?: boolean;
+}) => {
   const eventsListener = useCallback(
     (event: any) => {
       if (!event) {
@@ -72,7 +75,13 @@ const Pinwheel = ({
 
   return (
     <SafeAreaView style={styles.container}>
-      {linkToken && <RTNPinwheel style={{ flex: 1 }} token={linkToken} />}
+      {linkToken && (
+        <RTNPinwheel
+          style={{ flex: 1 }}
+          token={linkToken}
+          handleInsets={handleInsets ?? true}
+        />
+      )}
     </SafeAreaView>
   );
 };

--- a/src/RTNPinwheelNativeComponent.d.ts
+++ b/src/RTNPinwheelNativeComponent.d.ts
@@ -1,7 +1,8 @@
-import type { ViewProps } from "react-native";
-import type { HostComponent } from "react-native";
+import type { ViewProps } from 'react-native';
+import type { HostComponent } from 'react-native';
 export interface NativeProps extends ViewProps {
     token: string;
+    handleInsets: boolean;
 }
 declare const _default: HostComponent<NativeProps>;
 export default _default;

--- a/src/RTNPinwheelNativeComponent.ts
+++ b/src/RTNPinwheelNativeComponent.ts
@@ -1,15 +1,16 @@
-import type { ViewProps } from "react-native";
-import type { HostComponent } from "react-native";
-import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
+import type { ViewProps } from 'react-native';
+import type { HostComponent } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 type Event = {
-    name: string;
-}
+  name: string;
+};
 
 export interface NativeProps extends ViewProps {
-    token: string;
+  token: string;
+  handleInsets: boolean;
 }
 
 export default codegenNativeComponent<NativeProps>(
-  "RTNPinwheel"
+  'RTNPinwheel'
 ) as HostComponent<NativeProps>;


### PR DESCRIPTION
Changes:
- Upgrades the Android SDK dependency to 3.1.2, which handles window insets in edge-to-edge mode
- Adds a new (optional) prop `handleInsets` to the `<Pinwheel>` component, which is defaults to `true`. This provides a mechanism for disabling the handling of window insets in rare/bespoke instances where that's desired.
- Changelog and documentation will be updated in a subsequent PR