### PR TITLE
fix(ios): support static-framework builds via __has_include guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 # 4.x Releases
 
-- `4.x` Releases - [4.0.0](#400)
+- `4.x` Releases - [4.0.0](#400) | [4.0.1](#401)
+
+---
+
+### [4.0.1](https://www.npmjs.com/package/@pinwheel/react-native-pinwheel/v/4.0.1)
+
+- Fix iOS build failure when CocoaPods is configured with `use_frameworks! :linkage => :static`. The Swift bridging header is now imported using `__has_include` to prefer the framework-style path when available, with a fallback to the quoted import for static-library builds.
+- Bump iOS SDK to 4.0.1.
+- Bump Android SDK to 4.1.1.
 
 ---
 

--- a/RNPinwheelSDK.podspec
+++ b/RNPinwheelSDK.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
 
-  s.dependency 'PinwheelSDK', '4.0.0'
+  s.dependency 'PinwheelSDK', '4.0.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
   google()
 }
 
-def PW_ANDROID_SDK_VERSION = '4.0.0'
+def PW_ANDROID_SDK_VERSION = '4.1.1'
 
 dependencies {
     def pwVersion = rootProject.hasProperty('pwVersion') ? rootProject.pwVersion : PW_ANDROID_SDK_VERSION

--- a/android/src/main/java/com/rtnpinwheel/Pinwheel.kt
+++ b/android/src/main/java/com/rtnpinwheel/Pinwheel.kt
@@ -97,7 +97,7 @@ class Pinwheel : FrameLayout {
           val pinwheelFragment = PinwheelFragment.newInstanceWithAdvancedOptions(
             it,
             "react native",
-            "4.0.0",
+            "4.0.1",
             getReactNativeVersion(),
             this.handleInsets,
             this.useDarkMode,

--- a/ios/RTNPinwheelView.mm
+++ b/ios/RTNPinwheelView.mm
@@ -9,7 +9,11 @@
 
 #import "RCTFabricComponentsPlugins.h"
 #import "RTNPinwheelEvents.h"
+#if __has_include(<RNPinwheelSDK/RNPinwheelSDK-Swift.h>)
+#import <RNPinwheelSDK/RNPinwheelSDK-Swift.h>
+#else
 #import "RNPinwheelSDK-Swift.h"
+#endif
 
 using namespace facebook::react;
 
@@ -75,7 +79,7 @@ using namespace facebook::react;
       [[PWPinwheelWrapperVC alloc] initWithToken:self.token
                                         delegate:self
                                              sdk:@"react native"
-                                         version:@"4.0.0"
+                                         version:@"4.0.1"
                                   useSecureOrigin:self.useSecureOrigin
                                       useDarkMode:self.useDarkMode
                                useAppBoundDomains:NO
@@ -187,7 +191,11 @@ Class<RCTComponentViewProtocol> RTNPinwheelCls(void) {
 
 #import "RTNPinwheelEvents.h"
 #import "RTNPinwheelView.h"
+#if __has_include(<RNPinwheelSDK/RNPinwheelSDK-Swift.h>)
+#import <RNPinwheelSDK/RNPinwheelSDK-Swift.h>
+#else
 #import "RNPinwheelSDK-Swift.h"
+#endif
 
 @implementation RTNPinwheelView
 
@@ -244,7 +252,7 @@ Class<RCTComponentViewProtocol> RTNPinwheelCls(void) {
       [[PWPinwheelWrapperVC alloc] initWithToken:self.token
                                         delegate:self
                                              sdk:@"react native"
-                                         version:@"4.0.0"
+                                         version:@"4.0.1"
                                   useSecureOrigin:self.useSecureOrigin
                                       useDarkMode:self.useDarkMode
                                useAppBoundDomains:NO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-native-pinwheel",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-native-pinwheel",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react-native": "^0.72.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-native-pinwheel",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
### TL;DR

Fixes an iOS build failure when CocoaPods is configured with `use_frameworks! :linkage => :static`, bumping the version to `4.0.1`.

### What changed?

The Swift bridging header import in `RTNPinwheelView.mm` now uses `__has_include` to conditionally prefer the framework-style import path (`<RNPinwheelSDK/RNPinwheelSDK-Swift.h>`) when available, falling back to the quoted import (`"RNPinwheelSDK-Swift.h"`) for static-library builds.

### How to test?

Configure a React Native iOS project with CocoaPods using `use_frameworks! :linkage => :static` and verify the project builds successfully without errors related to the Swift bridging header import.

Tested and both builds pass:

- Build 1 (default static library): BUILD SUCCEEDED
- Build 2 (use_frameworks! :linkage => :static): BUILD SUCCEEDED

### Why make this change?

Projects using `use_frameworks! :linkage => :static` in their Podfile were experiencing iOS build failures because the quoted import path for the Swift bridging header is not valid in a framework context. The conditional import ensures compatibility with both framework and static-library CocoaPods configurations.