### PR TITLE
chore(example): Update example apps

### DIFF
--- a/example/ios/PinwheelRNExample.xcodeproj/project.pbxproj
+++ b/example/ios/PinwheelRNExample.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0C80B921A6F3F58F76C31292 /* libPods-PinwheelRNExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-PinwheelRNExample.a */; };
+		01C054268FFC4639D59EFCF9 /* libPods-PinwheelRNExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B197823CC5DF6FFD6A4CD744 /* libPods-PinwheelRNExample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -21,9 +21,9 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = PinwheelRNExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-PinwheelRNExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PinwheelRNExample.debug.xcconfig"; path = "Target Support Files/Pods-PinwheelRNExample/Pods-PinwheelRNExample.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-PinwheelRNExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PinwheelRNExample.release.xcconfig"; path = "Target Support Files/Pods-PinwheelRNExample/Pods-PinwheelRNExample.release.xcconfig"; sourceTree = "<group>"; };
-		5DCACB8F33CDC322A6C60F78 /* libPods-PinwheelRNExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PinwheelRNExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = PinwheelRNExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = PinwheelRNExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B197823CC5DF6FFD6A4CD744 /* libPods-PinwheelRNExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PinwheelRNExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C80B921A6F3F58F76C31292 /* libPods-PinwheelRNExample.a in Frameworks */,
+				01C054268FFC4639D59EFCF9 /* libPods-PinwheelRNExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5DCACB8F33CDC322A6C60F78 /* libPods-PinwheelRNExample.a */,
+				B197823CC5DF6FFD6A4CD744 /* libPods-PinwheelRNExample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -356,6 +356,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -429,6 +440,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -8,6 +8,8 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+install! 'cocoapods', :deterministic_uuids => false
+
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -31,5 +33,47 @@ target 'PinwheelRNExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Fix fmt consteval errors with Apple Clang 21+ (Xcode 26+).
+    #
+    # The fmt library's base.h auto-detects consteval support via an #if/#elif chain that
+    # unconditionally calls #define FMT_USE_CONSTEVAL 1, overriding any -D compiler flag.
+    # Apple Clang 21 (Xcode 26) has a stricter consteval implementation that rejects the
+    # FMT_STRING macro, so we patch base.h to wrap the auto-detection in #ifndef so that
+    # passing -DFMT_USE_CONSTEVAL=0 via OTHER_CPLUSPLUSFLAGS actually takes effect.
+    fmt_base_h = "#{installer.sandbox.root}/fmt/include/fmt/base.h"
+    if File.exist?(fmt_base_h)
+      content = File.read(fmt_base_h)
+      unless content.include?('FMT_USE_CONSTEVAL guard for Xcode 26+')
+        content = content.gsub(
+          "// Detect consteval, C++20 constexpr extensions and std::is_constant_evaluated.\n#if !defined(__cpp_lib_is_constant_evaluated)",
+          "// Detect consteval, C++20 constexpr extensions and std::is_constant_evaluated.\n// FMT_USE_CONSTEVAL guard for Xcode 26+ - allows compiler flag override\n#ifndef FMT_USE_CONSTEVAL\n#if !defined(__cpp_lib_is_constant_evaluated)"
+        )
+        content = content.gsub(
+          "#if FMT_USE_CONSTEVAL\n#  define FMT_CONSTEVAL consteval",
+          "#endif  // ifndef FMT_USE_CONSTEVAL\n#if FMT_USE_CONSTEVAL\n#  define FMT_CONSTEVAL consteval"
+        )
+        File.chmod(0644, fmt_base_h)
+        File.write(fmt_base_h, content)
+      end
+    end
+
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        existing = config.build_settings['OTHER_CPLUSPLUSFLAGS'] || '$(inherited)'
+        flags = existing.is_a?(Array) ? existing.join(' ') : existing
+        config.build_settings['OTHER_CPLUSPLUSFLAGS'] = "#{flags} -DFMT_USE_CONSTEVAL=0"
+      end
+    end
+
+    # Xcode 14+ signs resource bundles by default when building for devices.
+    installer.target_installation_results.pod_target_installation_results
+      .each do |pod_name, target_installation_result|
+      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+        resource_bundle_target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+      end
+    end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,9 +8,9 @@ PODS:
   - hermes-engine (0.79.4):
     - hermes-engine/Pre-built (= 0.79.4)
   - hermes-engine/Pre-built (0.79.4)
-  - PinwheelSDK (3.5.0):
-    - PinwheelSDK/PinwheelLinkSDK (= 3.5.0)
-  - PinwheelSDK/PinwheelLinkSDK (3.5.0)
+  - PinwheelSDK (4.0.0):
+    - PinwheelSDK/PinwheelLinkSDK (= 4.0.0)
+  - PinwheelSDK/PinwheelLinkSDK (4.0.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1657,11 +1657,11 @@ PODS:
     - React-logger (= 0.79.4)
     - React-perflogger (= 0.79.4)
     - React-utils (= 0.79.4)
-  - RNPinwheelSDK (3.7.0):
+  - RNPinwheelSDK (4.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
-    - PinwheelSDK (= 3.5.0)
+    - PinwheelSDK (= 4.0.0)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1918,7 +1918,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 8b5a5eb386b990287d072fd7b6f6ebd9544dd251
-  PinwheelSDK: ce9d956cf1473296bdeb60e419c90ab525785374
+  PinwheelSDK: 10ef63a296940bf271620cf5767fb20131abeedf
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 0418ac97b9f53b2e37f473da1663ef3061e46beb
   RCTRequired: b9fde7f981b11aa898f03a70d3d4d36b80f1b16d
@@ -1981,10 +1981,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bf62814e0fde923f73fc64b7e82d76c63c284da9
   ReactCodegen: f891084749d03b8af8a244cefaa492e491b763fd
   ReactCommon: c7d636ec1b9801ff4ee83cce8e0bf74a1610fc3f
-  RNPinwheelSDK: 32be57935124aae5df5156a8489ff064cc573377
+  RNPinwheelSDK: b20d57599e464f7ba16bd2a0a565a24074bf578e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a6cb833e04fb8c59a012b49fb1d040fcb0cbb633
 
-PODFILE CHECKSUM: 9a5ce636e40a8f517e94c999fb562d3094db9c7e
+PODFILE CHECKSUM: 9ec1cb2c0597b68c13a8e9c68e56d2805168eed4
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.17.0

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PinwheelRNExample",
       "version": "0.0.1",
       "dependencies": {
-        "@pinwheel/react-native-pinwheel": "file:../pinwheel-react-native-pinwheel-4.0.0.tgz",
+        "@pinwheel/react-native-pinwheel": "file:../pinwheel-react-native-pinwheel-4.0.1.tgz",
         "react": "19.0.0",
         "react-native": "0.79.4"
       },
@@ -2743,9 +2743,9 @@
       }
     },
     "node_modules/@pinwheel/react-native-pinwheel": {
-      "version": "4.0.0",
-      "resolved": "file:../pinwheel-react-native-pinwheel-4.0.0.tgz",
-      "integrity": "sha512-xt1mf3aUlHE/nBMmYCzqTX60l6/a2wlGudQ+XXmcn0P+9nKonZY2GpayYiOk+/je69QfUqwfvh6nCzCNGkWJZw==",
+      "version": "4.0.1",
+      "resolved": "file:../pinwheel-react-native-pinwheel-4.0.1.tgz",
+      "integrity": "sha512-Z67Kf8XkBhDJET8uTU/1yMftGIYZCUNPorSIlZZ6hNphmahI9q3AK6vlpc4ls71e9DHeqfiEWx7EmR3sqMiN3A==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@pinwheel/react-native-pinwheel": "file:../pinwheel-react-native-pinwheel-4.0.0.tgz",
+    "@pinwheel/react-native-pinwheel": "file:../pinwheel-react-native-pinwheel-4.0.1.tgz",
     "react": "19.0.0",
     "react-native": "0.79.4"
   },


### PR DESCRIPTION
## Changes

- Bump `@pinwheel/react-native-pinwheel` to `4.0.1`
- Add `fmt`/Xcode 26 fix to `Podfile` (already present in `example_expo`, was missing here)
- Add `install! 'cocoapods', :deterministic_uuids => false` to prevent UUID churn in `project.pbxproj` on every `pod install`
- Add `CODE_SIGNING_ALLOWED = 'NO'` for resource bundle targets to fix Xcode 14+ device builds